### PR TITLE
Add cert-manager installation job to GH workflow

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -41,5 +41,11 @@ jobs:
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+          kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
+          kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager
+
       - name: Run chart-testing (install)
         run: ct install --target-branch main

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,6 +46,7 @@ jobs:
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
           kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
           kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         run: ct install --target-branch main


### PR DESCRIPTION
Update `lint-test.yaml` by adding a job which would install cert-manager in the `kind` cluster and wait until it's ready. This should unblock the dependency problem another PR suffers.