### PR TITLE
Migrate KUTTL tests to Github workflow

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -53,3 +53,17 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --target-branch main
+
+      - name: Run KUTTL smoke tests
+        run: |
+          sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.0/kubectl-kuttl_0.11.0_linux_x86_64
+          sudo chmod +x /usr/local/bin/kubectl-kuttl
+          export PATH=$PATH:/usr/local/bin
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo update
+          sleep 5s
+          helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator
+          kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
+          git clone https://github.com/open-telemetry/opentelemetry-operator.git
+          kubectl kuttl test ./opentelemetry-operator/tests/e2e --config $GITHUB_WORKSPACE/charts/opentelemetry-operator/release/kuttl-test.yaml
+        if: steps.list-changed.outputs.operator-changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run KUTTL smoke tests
         run: |
-          sleep 10s
+          until kubectl get ns opentelemetry-operator-system 2>&1 | grep "namespaces \"opentelemetry-operator-system\" not found"; do sleep 1; done
           sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.0/kubectl-kuttl_0.11.0_linux_x86_64
           sudo chmod +x /usr/local/bin/kubectl-kuttl
           helm install my-opentelemetry-operator ./charts/opentelemetry-operator

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -60,8 +60,8 @@ jobs:
           sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.0/kubectl-kuttl_0.11.0_linux_x86_64
           sudo chmod +x /usr/local/bin/kubectl-kuttl
           export PATH=$PATH:/usr/local/bin
-          helm install my-opentelemetry-operator .
+          helm install my-opentelemetry-operator ./charts/opentelemetry-operator
           kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
           git clone https://github.com/open-telemetry/opentelemetry-operator.git
-          kubectl kuttl test ./opentelemetry-operator/tests/e2e --config $GITHUB_WORKSPACE/charts/opentelemetry-operator/release/kuttl-test.yaml
+          kubectl kuttl test ./opentelemetry-operator/tests/e2e --config ./charts/opentelemetry-operator/release/kuttl-test.yaml
         if: steps.list-changed.outputs.operator-changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run KUTTL smoke tests
         run: |
-          sleep 5s
+          sleep 10s
           sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.0/kubectl-kuttl_0.11.0_linux_x86_64
           sudo chmod +x /usr/local/bin/kubectl-kuttl
           export PATH=$PATH:/usr/local/bin

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -59,7 +59,6 @@ jobs:
           sleep 10s
           sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.0/kubectl-kuttl_0.11.0_linux_x86_64
           sudo chmod +x /usr/local/bin/kubectl-kuttl
-          export PATH=$PATH:/usr/local/bin
           helm install my-opentelemetry-operator ./charts/opentelemetry-operator
           kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
           git clone https://github.com/open-telemetry/opentelemetry-operator.git

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,13 +56,11 @@ jobs:
 
       - name: Run KUTTL smoke tests
         run: |
+          sleep 5s
           sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.0/kubectl-kuttl_0.11.0_linux_x86_64
           sudo chmod +x /usr/local/bin/kubectl-kuttl
           export PATH=$PATH:/usr/local/bin
-          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-          helm repo update
-          sleep 5s
-          helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator
+          helm install my-opentelemetry-operator .
           kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
           git clone https://github.com/open-telemetry/opentelemetry-operator.git
           kubectl kuttl test ./opentelemetry-operator/tests/e2e --config $GITHUB_WORKSPACE/charts/opentelemetry-operator/release/kuttl-test.yaml

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.1.0
+version: 0.1.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/release/kuttl-test.yaml
+++ b/charts/opentelemetry-operator/release/kuttl-test.yaml
@@ -1,0 +1,3 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+crdDir: ./charts/opentelemetry-operator/crds

--- a/charts/opentelemetry-operator/release/release-checklist.md
+++ b/charts/opentelemetry-operator/release/release-checklist.md
@@ -1,9 +1,3 @@
-# Prerequisites
-
-- [ ] Make sure you have installed KUTTL which will be used to do the smoke tests later. See [KUTTL website](https://kuttl.dev/docs/)
-  for installation information.
-- [ ] Make sure you have cloned the [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) in your workspace
-
 # Checklist
 
 - [ ] Change directory to `opentelemetry-helm-charts/charts/opentelemetry-operator/release`. `cd ./charts/opentelemetry-operator/release` should be helpful.
@@ -16,11 +10,8 @@
   Create a new YAML file under `templates` directory if it doesn't exist.
   Use `{{ template "opentelemetry-operator.name" . }}` to represent the name of OTEL Operator which probably is `opentelemetry-operator` in the manifest.
   Use `{{ template "opentelemetry-operator.namespace" . }}` to represent the namespace which probably is `opentelemetry-operator-system` in the manifest.
-- [ ] Test the Operator Helm chart locally:
-  - [ ] Change directory to the OpenTelemetry Operator
-  - [ ] Run the KUTTL smoke tests: `kubectl kuttl test ./tests/e2e`
-  - [ ] Make sure all KUTTL smoke tests pass
 - [ ] Update `README` if there is a breaking change in the Operator Helm chart
+- [ ] Bump chart version in `Chart.yaml`
 
 # Additional Context
 


### PR DESCRIPTION
**Description**

Currently, during every release of the operator Helm chart, maintainers need to clone the operator repo and run the KUTTL tests locally. This PR migrates the KUTTL tests to Github workflow so that the tests will run automatically when a new PR is submitted.